### PR TITLE
feat: add point_isin_boundary method to GeometryEntity

### DIFF
--- a/otary/geometry/entity.py
+++ b/otary/geometry/entity.py
@@ -206,6 +206,24 @@ class GeometryEntity(ABC):
 
         return np.array([])
 
+    def point_isin_boundary(
+        self,
+        point: NDArray,
+        error_dist: float,
+    ) -> bool:
+        """
+        Check whether a point lies on the boundary of the geometry.
+
+        Args:
+            point (NDArray): 2D point.
+            error_dist (float): Maximum allowed distance from the boundary.
+
+        Returns:
+            bool: True if the point lies on the boundary, False otherwise.
+        """
+        shapely_point = SPoint(point)
+        return shapely_point.distance(self.shapely_edges) <= error_dist
+
     @abstractmethod
     def enclosing_axis_aligned_bbox(self) -> AxisAlignedRectangle:
         """Compute the smallest area enclosing Axis-Aligned Bounding Box (AABB)

--- a/tests/unit/geometry/discrete/test_entity.py
+++ b/tests/unit/geometry/discrete/test_entity.py
@@ -459,6 +459,44 @@ class TestEntityDistVerticesToPoint:
         assert rect.longest_dist_vertices_to_point(point) == np.sqrt(2 * 10**2)
 
 
+class TestEntityPointIsInBoundary:
+
+    def test_point_exactly_on_edge_midpoint(self):
+        rect = Rectangle([[0, 0], [0, 2], [2, 2], [2, 0]])
+        point = np.array([1, 0])
+        assert rect.point_isin_boundary(point, error_dist=0.0) is True
+
+    def test_point_exactly_on_vertex(self):
+        rect = Rectangle([[0, 0], [0, 2], [2, 2], [2, 0]])
+        point = np.array([0, 0])
+        assert rect.point_isin_boundary(point, error_dist=0.0) is True
+
+    def test_point_within_tolerance_of_edge(self):
+        rect = Rectangle([[0, 0], [0, 2], [2, 2], [2, 0]])
+        point = np.array([1, 0.05])
+        assert rect.point_isin_boundary(point, error_dist=0.1) is True
+
+    def test_point_outside_tolerance_of_edge(self):
+        rect = Rectangle([[0, 0], [0, 2], [2, 2], [2, 0]])
+        point = np.array([1, 0.5])
+        assert rect.point_isin_boundary(point, error_dist=0.1) is False
+
+    def test_point_inside_shape_not_on_boundary(self):
+        rect = Rectangle([[0, 0], [0, 2], [2, 2], [2, 0]])
+        point = np.array([1, 1])
+        assert rect.point_isin_boundary(point, error_dist=0.01) is False
+
+    def test_point_far_outside_shape(self):
+        rect = Rectangle([[0, 0], [0, 2], [2, 2], [2, 0]])
+        point = np.array([5, 5])
+        assert rect.point_isin_boundary(point, error_dist=0.01) is False
+
+    def test_zero_error_dist_requires_exact_match(self):
+        rect = Rectangle([[0, 0], [0, 2], [2, 2], [2, 0]])
+        point = np.array([1, 0.0001])
+        assert rect.point_isin_boundary(point, error_dist=0.0) is False
+
+
 class TestEntitySharedApproxVertices:
     def test_shared_vertices_with_overlap(self):
         entity1 = Rectangle([[0, 0], [0, 2], [2, 2], [2, 0]])


### PR DESCRIPTION
Adds point_isin_boundary to GeometryEntity (closes #29).

Checks whether a point lies on the boundary of a geometry within a configurable distance tolerance, using Shapely's distance computation instead of relying on exact floating-point comparisons.

The method signature matches the one proposed in the issue.