### PR TITLE
Fix/show non uint8 images

### DIFF
--- a/otary/image/components/io/writer.py
+++ b/otary/image/components/io/writer.py
@@ -2,6 +2,7 @@
 WriterImage module
 """
 
+import numpy as np
 from PIL import Image as ImagePIL
 
 from otary.image.base import BaseImage
@@ -40,7 +41,13 @@ class WriterImage:
         figsize = (int(figsize[0]), int(figsize[1]))
 
         self.base.as_reversed_color_channel()
-        im = self.base.as_pil().resize(size=figsize)
+
+        array = self.base.asarray
+
+        if array.dtype != np.uint8:
+            array = np.clip(array, 0, 255).astype(np.uint8)
+
+        im = ImagePIL.fromarray(array).resize(size=figsize)
 
         if popup_window_display:
             im.show()

--- a/tests/unit/image/components/io/test_writer.py
+++ b/tests/unit/image/components/io/test_writer.py
@@ -4,6 +4,7 @@ Unit tests for the writer image class
 
 from unittest import mock
 import numpy as np
+import pytest
 from otary.image import Image
 
 
@@ -18,6 +19,32 @@ class TestWriterShow:
         arr = np.ones((3, 3, 3), dtype=np.uint8)
         im = Image(arr)
         im.show()
+
+    @pytest.mark.parametrize(
+        "dtype",
+        [
+            np.float32,
+            np.float64,
+            np.int32,
+            np.uint16,
+        ],
+    )
+    def test_show_non_uint8_image(self, dtype):
+        arr = np.ones((3, 3, 3), dtype=dtype)
+        im = Image(arr)
+        im.show()
+
+    @mock.patch("otary.image.components.io.writer.ImagePIL.fromarray")
+    def test_show_clips_non_uint8_image(self, mock_fromarray):
+        arr = np.array([[[-10, 0, 300]]], dtype=np.float32)
+        im = Image(arr)
+        im.show()
+
+        passed_array = mock_fromarray.call_args.args[0]
+
+        assert passed_array.dtype == np.uint8
+        assert passed_array.min() == 0
+        assert passed_array.max() == 255
 
     @mock.patch("PIL.Image.Image.show")
     def test_show_popup_window(self, mock_show):


### PR DESCRIPTION
### Summary

This PR fixes `Image.show()` failing for non-`uint8` image arrays that Pillow cannot directly render.

The rendering path now:
* Clips non-uint8 arrays to the expected [0, 255] display range.
* Converts the temporary array to uint8 before passing it to Pillow.
* Keeps the original image dtype unchanged.

### Testing

Added tests covering non-`uint8` image rendering. 
* Verify the values outside intended `[0, 255]` range are clipped correctly. 
* Verify dtype is changed to `uint8` before passing object to Pillow for rendering

Fixes #49 