### PR TITLE
Fix/show bgr channel mutation

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,12 @@ Using Otary makes the code:
 - Much more **interactive**
 - Much simpler, simplifying **libraries management** by only using one library and not manipulating multiple libraries like Pillow, OpenCV, Scikit-Image, PyMuPDF etc.
 
+## Image Channel Order
+
+Otary follows OpenCV's BGR channel convention for 3-channel image arrays. Make sure the image arrays are in BGR order when working with Otary.
+
+If the image is already in RGB order, pass `is_bgr=False` when calling output methods such as `show()` or `save()`.
+
 ## Enhanced Interactivity
 
 In a Jupyter notebook, you can easily test and iterate on transformations by simply commenting part of the code as you need it.

--- a/docs/api/image/index.md
+++ b/docs/api/image/index.md
@@ -17,6 +17,22 @@ im.save(save_filepath="path/to/file/image")
 im.show()
 ```
 
+## Image Channel Order
+
+Otary follows OpenCV's BGR channel convention for 3-channel images. Make sure image arrays are in BGR order when working with Otary.
+
+If the image is already in RGB order, pass `is_bgr=False` when calling output methods such as `show()` or `save()`.
+
+```python
+import otary as ot
+
+im = ot.Image(rgb_array)
+
+im.show(is_bgr=False)
+
+im.save("output.png", is_bgr=False)
+```
+
 ## Components
 
 The `image` module is built around the following components:

--- a/otary/image/base.py
+++ b/otary/image/base.py
@@ -197,6 +197,20 @@ class BaseImage:
         """
         return np.array([0, 0], dtype=int)
 
+    def as_rgb_array(self, is_bgr: bool = True) -> NDArray:
+        """Return RGB ordered array without mutating image
+
+        Args:
+            is_bgr (bool, optional): whether image is BGR format.
+                Defaults to True.
+
+        Returns:
+            NDArray: RGB ordered image array when image has 3 channels.
+        """
+        if is_bgr and not self.is_gray and self.channels == 3:
+            return self.asarray[..., ::-1]
+        return self.asarray
+
     def as_pil(self) -> ImagePIL.Image:
         """Return the image as PIL Image
 

--- a/otary/image/components/io/writer.py
+++ b/otary/image/components/io/writer.py
@@ -17,6 +17,7 @@ class WriterImage:
         self,
         figsize: tuple[float, float] = (-1, -1),
         popup_window_display: bool = False,
+        is_bgr: bool = True,
     ) -> ImagePIL.Image:
         """Show the image
 
@@ -25,6 +26,8 @@ class WriterImage:
                 Defaults to (-1, -1), meaning the original size of the image.
             popup_window_display (bool, optional): whether to display the image in a
                 popup window. Defaults to False.
+            is_bgr (bool, optional): whether image is BGR format.
+                Defaults to True.
         """
         if figsize[0] <= 0 and figsize[1] <= 0:
             figsize = (self.base.width, self.base.height)
@@ -39,18 +42,23 @@ class WriterImage:
 
         figsize = (int(figsize[0]), int(figsize[1]))
 
-        self.base.as_reversed_color_channel()
-        im = self.base.as_pil().resize(size=figsize)
+        array = self.base.as_rgb_array(is_bgr=is_bgr)
+
+        im = ImagePIL.fromarray(array).resize(size=figsize)
 
         if popup_window_display:
             im.show()
 
         return im
 
-    def save(self, fp: str) -> None:
+    def save(self, fp: str, is_bgr: bool = True) -> None:
         """Save the image in a local file
 
         Args:
             fp (str): fp stands for filepath which is the path to the file
+            is_bgr (bool, optional): whether image is BGR format.
+                Defaults to True.
         """
-        self.base.as_reversed_color_channel().as_pil().save(fp)
+        array = self.base.as_rgb_array(is_bgr=is_bgr)
+
+        ImagePIL.fromarray(array).save(fp)

--- a/otary/image/image.py
+++ b/otary/image/image.py
@@ -417,18 +417,21 @@ class Image:
 
     # -------------------------------- WRITE METHODS ----------------------------------
 
-    def save(self, fp: str) -> None:
+    def save(self, fp: str, is_bgr: bool = True) -> None:
         """Save the image in a local file
 
         Args:
             fp (str): fp stands for filepath which is the path to the file
+            is_bgr (bool, optional): whether image is BGR format.
+                Defaults to True.
         """
-        self.writer.save(fp=fp)
+        self.writer.save(fp=fp, is_bgr=is_bgr)
 
     def show(
         self,
         figsize: tuple[float, float] = (-1, -1),
         popup_window_display: bool = False,
+        is_bgr: bool = True,
     ) -> ImagePIL.Image:
         """Show the image
 
@@ -437,9 +440,11 @@ class Image:
                 Defaults to (-1, -1), meaning the original size of the image.
             popup_window_display (bool, optional): whether to display the image in a
                 popup window. Defaults to False.
+            is_bgr (bool, optional): whether image is BGR format.
+                Defaults to True.
         """
         return self.writer.show(
-            figsize=figsize, popup_window_display=popup_window_display
+            figsize=figsize, popup_window_display=popup_window_display, is_bgr=is_bgr
         )
 
     # -------------------------------- DRAWER METHODS ---------------------------------

--- a/tests/unit/image/components/io/test_writer.py
+++ b/tests/unit/image/components/io/test_writer.py
@@ -19,6 +19,16 @@ class TestWriterShow:
         im = Image(arr)
         im.show()
 
+    def test_show_does_not_mutate_array(self):
+        arr = np.array([[[10, 20, 30]]], dtype=np.uint8)
+        im = Image(arr)
+
+        im.show()
+        assert np.array_equal(im.asarray, arr)
+
+        im.show()
+        assert np.array_equal(im.asarray, arr)
+
     @mock.patch("PIL.Image.Image.show")
     def test_show_popup_window(self, mock_show):
         arr = np.ones((3, 3, 3), dtype=np.uint8)
@@ -27,6 +37,17 @@ class TestWriterShow:
 
 
 class TestWriterSave:
+
+    @mock.patch("PIL.Image.Image.save")
+    def test_save_does_not_mutate_array(self, mock_save):
+        arr = np.array([[[10, 20, 30]]], dtype=np.uint8)
+        im = Image(arr)
+
+        im.save("output.png")
+        assert np.array_equal(im.asarray, arr)
+
+        im.save("output.png")
+        assert np.array_equal(im.asarray, arr)
 
     @mock.patch("PIL.Image.Image.save")
     def test_save_calls_show_with_filepath(self, mock_save):

--- a/tests/unit/image/test_base.py
+++ b/tests/unit/image/test_base.py
@@ -14,6 +14,42 @@ class TestBaseImageGlobalMethods:
         assert len(img.shape_array) == 3
 
 
+class TestBaseImageAsRgbArray:
+
+    def test_as_rgb_array_reverses_color_channels(self):
+        arr = np.array([[[10, 20, 30]]], dtype=np.uint8)
+        img = Image(arr)
+
+        rgb = img.base.as_rgb_array()
+
+        assert np.array_equal(rgb, [[[30, 20, 10]]])
+
+    def test_as_rgb_array_does_not_mutate_array(self):
+        arr = np.array([[[10, 20, 30]]], dtype=np.uint8)
+        img = Image(arr)
+
+        img.base.as_rgb_array()
+
+        assert np.array_equal(img.asarray, arr)
+
+    def test_as_rgb_array_keeps_rgb(self):
+        arr = np.array([[[10, 20, 30]]], dtype=np.uint8)
+        img = Image(arr)
+
+        rgb = img.base.as_rgb_array(is_bgr=False)
+
+        assert np.array_equal(rgb, arr)
+        assert np.array_equal(img.asarray, arr)
+
+    def test_as_rgb_array_keeps_grayscale(self):
+        arr = np.array([[1, 2], [3, 4]], dtype=np.uint8)
+        img = Image(arr)
+
+        rgb = img.base.as_rgb_array()
+
+        assert np.array_equal(rgb, arr)
+
+
 class TestImageAsArray:
 
     def test_asarray_getter(self):


### PR DESCRIPTION
Summary

This PR fixes `Image.show()` and `Image.save()` mutating image color channels while converting BGR channel order for output.

The output path now:

  - Converts BGR to RGB using a temporary array view.
  - Keeps the original image array unchanged.
  - Adds `is_bgr` to allow RGB inputs to skip channel reversal.

Testing

 Added tests covering non mutating BGR output.

  - Verify `as_rgb_array()` reverses color channels.
  - Verify `as_rgb_array()` does not mutate image array.
  - Verify RGB and grayscale inputs are preserved correctly.
  - Verify repeated `show()` and `save()` calls do not mutate image data.

Fixes #8 